### PR TITLE
refact/metrics: use cloudwatch metrics instead of prometheus

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,13 +21,14 @@ class Spot():
         self.region = region
         self.instance_id = instance_id
 
+        self.cw = boto3.client('cloudwatch')
+
         self.session = self.assume_role(session)
 
         self.alb = self.session.client('elbv2')
         self.elb = self.session.client('elb')
         self.ec2 = self.session.client('ec2')
         self.asg = self.session.client('autoscaling')
-        self.cw = self.session.client('cloudwatch')
 
         self.current_asg = self.get_current_asg()
 

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ class Spot():
                  region,
                  role_name,
                  instance_id,
-                 agg_gw,
+                 metrics_namespace,
                  session=boto3):
         self.account_id = account_id
         self.role_name = role_name
@@ -27,6 +27,7 @@ class Spot():
         self.elb = self.session.client('elb')
         self.ec2 = self.session.client('ec2')
         self.asg = self.session.client('autoscaling')
+        self.cw = self.session.client('cloudwatch')
 
         self.current_asg = self.get_current_asg()
 
@@ -37,33 +38,35 @@ class Spot():
         )
         self.lb_type, self.resource_id = self.find_tg()
 
-        self.agg_gw = agg_gw
+        self.metrics_namespace = metrics_namespace
         self.prefix = 'lambda_spot_interruption_'
 
         self.metric(name='termination', reason='termination')
 
-    def metric(self, name, reason, extra_labels=None, value=1):
-        if self.agg_gw is None:
+    def metric(self, name, reason, value=1):
+        if self.metrics_namespace is None:
             return
 
-        if self.resource_id is None:
-            tg_name = 'could not find'
-        else:
-            tg_name = self.resource_id.split('/')[1]
-
-        labels = f'account_id="{self.account_id}",asg="{self.current_asg}",lb_type="{self.lb_type}",tg="{tg_name}",reason="{reason}"'
-        if extra_labels is not None:
-            labels += f',{extra_labels}'
-
-        metric = f"{self.prefix}{name}{{{labels}}} {value}\n"
-        try:
-            req = requests.post(
-                self.agg_gw,
-                data=metric,
-                headers={'Content-Type': 'text/xml'},
-                timeout=2)
-        except Timeout:
-            print('Timed out while trying to post metrics!')
+        self.cw.put_metric_data(
+            Namespace=self.metrics_namespace,
+            MetricData=[{
+                'MetricName':
+                name,
+                'Value':
+                value,
+                'Unit':
+                'Count',
+                'Dimensions': [{
+                    'Name': 'AutoScaleGroup',
+                    'Value': self.current_asg
+                }, {
+                    'Name': 'AccountID',
+                    'Value': self.account_id
+                }, {
+                    'Name': 'Status',
+                    'Value': reason
+                }]
+            }])
 
     def assume_role(self, session):
         arn = f"arn:aws:iam::{self.account_id}:role/{self.role_name}"
@@ -216,15 +219,15 @@ def handler(event, context):
     account_id = event['account']
     region = event['region']
     role_name = os.environ['ROLE_NAME']
-    agg_gw = os.getenv('AGG_GW',
-                       None)  # weaveworks prom-aggregation-gateway endpoint
+    metrics_namespace = os.getenv('CW_METRICS_NAMESPACE', None)
 
     print(
         f"Instance {instance_id} in account {account_id} in region {region} is going down"
     )
 
     try:
-        spot = Spot(account_id, region, role_name, instance_id, agg_gw)
+        spot = Spot(account_id, region, role_name, instance_id,
+                    metrics_namespace)
 
         # Drain the target group or load balancer if configured
         spot.drain_from_lb()

--- a/policy.json
+++ b/policy.json
@@ -5,6 +5,7 @@
         "Effect": "Allow",
         "Action": [
             "autoscaling:DescribeAutoScalingInstances",
+            "cloudwatch:PutMetricData",
             "autoscaling:SetDesiredCapacity",
             "ec2:DescribeTags",
             "autoscaling:DescribeTags",


### PR DESCRIPTION
prometheus cant give precise metrics so refact it to use cloudwatch instead